### PR TITLE
switch from vim-inspector to nvim-dap for debugging

### DIFF
--- a/nvim/.config/nvim/after/plugin/dap.lua
+++ b/nvim/.config/nvim/after/plugin/dap.lua
@@ -1,0 +1,50 @@
+local dap = require("dap")
+local dap_ui = require("dapui")
+local dap_virtual_text = require("nvim-dap-virtual-text")
+dap.adapters.node2 = {
+  type = 'executable',
+  command = 'node',
+  args = { os.getenv('HOME') .. '/.local/share/vscode-node-debug2/out/src/nodeDebug.js' },
+}
+dap.configurations.javascript = {
+  {
+    name = 'Launch',
+    type = 'node2',
+    request = 'attach',
+    cwd = vim.fn.getcwd(),
+    sourceMaps = true,
+    protocol = 'inspector',
+    console = 'integratedTerminal',
+    skipFiles = { '<node_internals>/**/*.js' },
+  },
+  {
+    -- For this to work you need to make sure the node process is started with the `--inspect` flag.
+    name = 'Attach to process',
+    type = 'node2',
+    request = 'attach',
+    processId = require 'dap.utils'.pick_process,
+  },
+}
+
+dap.adapters.coreclr = {
+  type = "executable",
+  command = "/usr/local/netcoredbg",
+  args = { "--interpreter=vscode" },
+}
+
+dap.configurations.cs = {
+  {
+    type = "coreclr",
+    name = "launch - netcoredbg",
+    request = "launch",
+    program = function()
+      return vim.fn.input('Path to dll: ', vim.fn.getcwd() .. '/bin/Debug/', 'file')
+    end,
+  },
+}
+
+dap_ui.setup()
+dap_virtual_text.setup()
+
+vim.fn.sign_define('DapBreakpoint', { text = '🟥', texthl = '', linehl = '', numhl = '' })
+vim.fn.sign_define('DapBreakpointRejected', { text = '🟦', texthl = '', linehl = '', numhl = '' })

--- a/nvim/.config/nvim/filetype.lua
+++ b/nvim/.config/nvim/filetype.lua
@@ -5,15 +5,54 @@ local _local_csharp_options = {
   shiftwidth = 4,
 }
 
-local set_options = function()
+-- TODO: refactor - too many repeated functions for setting keymaps | noremap is used too many times
+-- check what these callbacks are passed, maybe the file extension?
+-- if callback is passed filetype
+--  I could map configuration in a table for each filetype
+--  and loop over it
+local set_and_run_cs_files = function()
   for key, value in pairs(_local_csharp_options) do
     _global_opts[key] = value
   end
+  vim.keymap.set('n', '<leader>rf', ':w | :!dotnet run<CR>', { noremap = true })
+end
+
+local run_lua_files = function()
+  vim.keymap.set('n', '<leader>rf', ':w | luafile %<CR>', { noremap = true })
+end
+
+local run_bash_files = function()
+  vim.keymap.set('n', '<leader>rf', ':w | :!./%<CR>', { noremap = true })
+end
+
+local run_js_files = function()
+  vim.keymap.set('n', '<leader>rf', ':w | :!node %<CR>', { noremap = true })
 end
 
 vim.api.nvim_create_autocmd(
   { "FileType", "BufEnter" },
   {
     pattern = { "*.cs", "*.csharp" },
-    callback = set_options,
+    callback = set_and_run_cs_files,
+  })
+
+vim.api.nvim_create_autocmd(
+  { "FileType", "BufEnter" },
+  {
+    pattern = { "*.bash", "*.sh", "sh" },
+    callback = run_bash_files,
+  })
+
+vim.api.nvim_create_autocmd(
+  { "FileType", "BufEnter" },
+  {
+    pattern = { "*.lua" },
+    callback = run_lua_files,
+  })
+
+vim.api.nvim_create_autocmd(
+  { "FileType", "BufEnter" },
+  {
+    pattern = { "*.js" },
+    callback = run_js_files,
   })

--- a/nvim/.config/nvim/mappings.vim
+++ b/nvim/.config/nvim/mappings.vim
@@ -45,6 +45,19 @@ nnoremap <Leader>rs :w <Bar> !./%
 " Vim zoom
 nnoremap <C-W>z <Plug>(zoom-toggle)
 
+" Debugging
+nnoremap <silent> <F5> <Cmd>lua require'dap'.continue()<CR>
+nnoremap <silent> <F10> <Cmd>lua require'dap'.step_over()<CR>
+nnoremap <silent> <F11> <Cmd>lua require'dap'.step_into()<CR>
+nnoremap <silent> <F12> <Cmd>lua require'dap'.step_out()<CR>
+nnoremap <silent> <Leader>b <Cmd>lua require'dap'.toggle_breakpoint()<CR>
+nnoremap <silent> <Leader>B <Cmd>lua require'dap'.set_breakpoint(vim.fn.input('Breakpoint condition: '))<CR>
+nnoremap <silent> <Leader>lp <Cmd>lua require'dap'.set_breakpoint(nil, nil, vim.fn.input('Log point message: '))<CR>
+nnoremap <silent> <Leader>dr <Cmd>lua require'dap'.repl.open()<CR>
+nnoremap <silent> <Leader>dl <Cmd>lua require'dap'.run_last()<CR>
+nnoremap <silent> <Leader>dl <Cmd>lua require'dap'.run_last()<CR>
+nnoremap <silent> <leader>dq :lua require'dapui'.toggle()<CR>
+
 " Get absolute path of current file
 nnoremap <Leader>. :echo expand('%:p')<CR>
 

--- a/nvim/.config/nvim/vim-plug/plugins.vim
+++ b/nvim/.config/nvim/vim-plug/plugins.vim
@@ -83,8 +83,9 @@ Plug 'hrsh7th/cmp-path'
 Plug 'tpope/vim-scriptease'
 
 " Debugger
-Plug 'puremourning/vimspector'
-
+Plug 'mfussenegger/nvim-dap'
+Plug 'rcarriga/nvim-dap-ui'
+Plug 'theHamsta/nvim-dap-virtual-text'
 " Markdown
 Plug 'iamcco/markdown-preview.nvim', { 'do': { -> mkdp#util#install() }, 'for': ['markdown', 'vim-plug']}
 


### PR DESCRIPTION
Test nvim-dap for debugging and provided simpler configuration and setup. Also, I added the support to execute the same command for running different programs.