### PR TITLE
Remove unnecessary if staterment in zsh-exec

### DIFF
--- a/zsh/.config/zsh/zsh-exec
+++ b/zsh/.config/zsh/zsh-exec
@@ -21,6 +21,7 @@ case "${UNAME_OUT}" in
     else
       echo -e "No need to start dropbox" 
     fi
-
+    # Adds  brew /bin to path
+    eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
     ;;
 esac

--- a/zsh/.config/zsh/zsh-exec
+++ b/zsh/.config/zsh/zsh-exec
@@ -10,15 +10,11 @@ case "${UNAME_OUT}" in
       dropbox start &>/dev/null
     fi
 
-    # Causes issues in Linux +Man, Man page exited with code 127
-    if command -v apt &>/dev/null;
-    then 
-      export MANPAGER='vim +Man!'
-      nvidia-settings -a '[gpu:0]/GPUFanControlState=1' &> /dev/null
-      nvidia-settings -a '[fan]/GPUTargetFanSpeed=50' &> /dev/null
-    fi
+    export MANPAGER='vim +Man!'
+    nvidia-settings -a '[gpu:0]/GPUFanControlState=1' &> /dev/null
+    nvidia-settings -a '[fan]/GPUTargetFanSpeed=50' &> /dev/null
 
-    if command -v apt &>/dev/null && (pgrep tmux &>/dev/null && ! pgrep dropbox &>/dev/null);
+    if pgrep tmux &>/dev/null && ! pgrep dropbox &>/dev/null;
     then
       tmux rename-window running-dropbox &>/dev/null
       dropbox start &>/dev/null


### PR DESCRIPTION
a case statement was used in zsh-exec to determine if current shell is running in a Linux or Darwin machine. Therefore, any subsequent calls to <command -v apt> was unnecessary. 