### PR TITLE
fix(tmux): move <tmux popup -E lazygit> to Linux only

### DIFF
--- a/tmux/.config/tmux/.tmux.conf
+++ b/tmux/.config/tmux/.tmux.conf
@@ -233,11 +233,9 @@ bind-key a resize-pane -Z \; choose-tree "resize-pane -Z \; select-window -t '%%
 # Kill all panes but current
 bind-key o kill-pane -a
 
-bind-key g popup -h 80% -w 80% -T lazygit -d "#{pane_current_path}" -E "lazygit"
-
 # new pane {lazygit} and ctrl-z to go fullscreen
-# bind-key g split-window -c "#{pane_current_path}" \; send-keys lg Enter \; resize-pane -Z
+bind-key g split-window -c "#{pane_current_path}" \; send-keys lg Enter \; resize-pane -Z
 # bind-key u - exit {lazygit} and resize -Z last used pane 
-# bind-key u kill-pane \; resize-pane -Z
+bind-key u kill-pane \; resize-pane -Z
 
 run '~/.tmux/plugins/tpm/tpm'

--- a/zsh/.config/zsh/zsh-exec
+++ b/zsh/.config/zsh/zsh-exec
@@ -21,6 +21,11 @@ case "${UNAME_OUT}" in
     else
       echo -e "No need to start dropbox" 
     fi
+
+    if pgrep tmux &>/dev/null;
+    then
+      tmux bind-key g popup -h 80% -w 80% -T lazygit -d "#{pane_current_path}" -E "lazygit"
+    fi
     # Adds  brew /bin to path
     eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
     ;;


### PR DESCRIPTION
Running lazygit in tmux popup pane on Mac was causing unexpected errors.
Moved temporarily this command <tmux popup -E lazygit> when shell is
running in a Linux machine and there is a running tmux process.