### PR TITLE
Aliases and FZF options for export

### DIFF
--- a/zsh/.config/zsh/zsh-aliases
+++ b/zsh/.config/zsh/zsh-aliases
@@ -28,7 +28,7 @@ alias pscpu='ps auxf | sort -nr -k 3 | head -5'
 alias gital='cat $ZDOTDIR/zsh-aliases | tail -21'
 
 # Start Tmux with $XDG_CONFIG_HOME/tmux/*.tmux.conf
-alias tmux='tmux -f $XDG_CONFIG_HOME/tmux/.tmux.conf' 
+alias tmux="tmux -f $XDG_CONFIG_HOME/tmux/.tmux.conf"
 
 # Browser sync
 alias bss="browser-sync start --server --files '**/*.css, **/*.html, **/*.js, !node_modules/**/*' --directory --port 7777"

--- a/zsh/.config/zsh/zsh-exports
+++ b/zsh/.config/zsh/zsh-exports
@@ -22,14 +22,18 @@ HISTFILE="$XDG_DATA_HOME"/zsh/history/.zsh_history
 HISTSIZE=1000000
 SAVEHIST=1000000
 
+#FZF
+export FZF_DEFAULT_OPTS='
+    --layout=reverse
+    --color fg:#ebdbb2,bg:#121212,hl:#ffa348,fg+:#ebdbb2,bg+:#3c3836,hl+:#fabd2f
+    --color info:#83a598,prompt:#ffa348,spinner:#fabd2f,pointer:#ffa348,marker:#ffa348,header:#665c54
+    --height 40%
+'
 
 # for zsh viins to work jj 'vi-cmd-mode'
 export KEYTIMEOUT=15
 
 export NVIM_DOTFILES="$XDG_CONFIG_HOME/nvim"
-
-
-export PATH=$HOME/.dotnet/tools:$PATH
 
 export STARSHIP_CONFIG=$XDG_CONFIG_HOME/starship/config.toml
 


### PR DESCRIPTION
Fix tmux alias not expanding the XDG_CONFIG_HOME environment variable in config file. I also export FZF_DEFAULT_OPTS for all shell instances to configure the looks of FZF