### PR TITLE
Update nvim lsp client capabilities api

### DIFF
--- a/nvim/.config/nvim/after/plugin/lspconfig.rc.lua
+++ b/nvim/.config/nvim/after/plugin/lspconfig.rc.lua
@@ -77,11 +77,13 @@ local on_custom_attach = function(client, bufnr)
     vim.keymap.set("n", "ff", vim.lsp.buf.formatting, opts)
 
     --formatting
-    if client.server_capabilities.document_formatting then
-        vim.api.nvim_command [[augroup Format]]
-        vim.api.nvim_command [[autocmd! * <buffer>]]
-        vim.api.nvim_command [[autocmd BufWritePre <buffer> lua vim.lsp.buf.formatting_seq_sync()]]
-        vim.api.nvim_command [[augroup END]]
+    if client.resolved_capabilities.document_formatting then
+        vim.api.nvim_create_autocmd("BufWritePre", {
+            buffer = bufnr,
+            callback = function()
+                vim.lsp.buf.format()
+            end
+        })
     end
 
 


### PR DESCRIPTION
After writing to files, formatting was not triggered. This was caused because of deprecated API `client.server_capabilities.document_formatting`. This was returning `nil`. 

I updated nvim API `client.resolved_capabilities.document_formatting`.